### PR TITLE
Do not send emails while in airplane mode

### DIFF
--- a/airplane-mode.php
+++ b/airplane-mode.php
@@ -52,6 +52,12 @@ class Airplane_Mode_Core
 	 * there are many like it, but this one is mine
 	 */
 	private function __construct() {
+
+		global $phpmailer;
+
+		// Override WordPress mailer class with a mock mailer.
+		$phpmailer = new MockPHPMailer();
+
 		add_action		(	'plugins_loaded',						array(  $this,  'textdomain'			)			);
 
 		add_action		(	'wp_default_styles',					array(	$this,	'block_style_load'		),	100		);
@@ -349,6 +355,9 @@ class Airplane_Mode_Core
 
 /// end class
 }
+
+// Include dependencies
+require_once( 'lib/mock-mailer.php' );
 
 // Instantiate our class
 $Airplane_Mode_Core = Airplane_Mode_Core::getInstance();

--- a/lib/mock-mailer.php
+++ b/lib/mock-mailer.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Class taken from WordPress.org test suite.
+ * See
+ * https://core.trac.wordpress.org/browser/trunk/tests/phpunit/includes
+ */
+require_once( ABSPATH . 'wp-includes/class-phpmailer.php' );
+
+class MockPHPMailer extends PHPMailer {
+	var $mock_sent = array();
+
+	/**
+	 * Override send() so mail isn't actually sent.
+	 */
+	function send() {
+		try {
+			if ( ! $this->preSend() )
+				return false;
+
+			$this->mock_sent[] = array(
+				'to'     => $this->to,
+				'cc'     => $this->cc,
+				'bcc'    => $this->bcc,
+				'header' => $this->MIMEHeader,
+				'body'   => $this->MIMEBody,
+			);
+
+			return true;
+		} catch ( phpmailerException $e ) {
+			return false;
+		}
+	}
+}


### PR DESCRIPTION
As per the subject. This utilises the MockMailer class from https://core.trac.wordpress.org/browser/trunk/tests/phpunit/includes/ to override the global $phpmailer object to prevent emails being sent. 

The caveat being that if something (broken plugin?) overrides $phpmailer, then WordPress _will_ recreate a normal PHPMailer object. Probably needs a core change to fix that - see https://core.trac.wordpress.org/ticket/28618
