### PR TITLE
Blocking AJAX requests when Airplane Mode is enabled

### DIFF
--- a/airplane-mode.php
+++ b/airplane-mode.php
@@ -63,9 +63,9 @@ class Airplane_Mode_Core {
 
         // settings
         add_action( 'admin_bar_menu',        array( $this, 'admin_bar_toggle' ), 9999 );
-        add_action( 'wp_enqueue_scripts',    array( $this, 'toggle_css'       ), 9999 );
-        add_action( 'admin_enqueue_scripts', array( $this, 'toggle_css'       ), 9999 );
-        add_action( 'login_enqueue_scripts', array( $this, 'toggle_css'       ), 9999 );
+        add_action( 'wp_enqueue_scripts',    array( $this, 'toggle_assets'    ), 9999 );
+        add_action( 'admin_enqueue_scripts', array( $this, 'toggle_assets'    ), 9999 );
+        add_action( 'login_enqueue_scripts', array( $this, 'toggle_assets'    ), 9999 );
 
         // keep jetpack from attempting external requests
         if ( $this->enabled() ) {
@@ -243,11 +243,15 @@ class Airplane_Mode_Core {
     }
 
     /**
-     * load our small CSS file for the toggle switch
-     * @return [type] [description]
+     * load our JS and CSS files
      */
-    public function toggle_css() {
+    public function toggle_assets() {
         wp_enqueue_style( 'airplane-mode', plugins_url( '/lib/css/airplane-mode.css', __FILE__), array(), AIRMDE_VER, 'all' );
+        wp_enqueue_script( 'airplane-mode', plugins_url( '/lib/js/airplane-mode.js', __FILE__), array(), AIRMDE_VER );
+        wp_localize_script( 'airplane-mode', 'airmde', array(
+        	'enabled' => $this->enabled(),
+        	'aborted' => __( 'Airplane Mode is enabled. Aborted AJAX request to %1$s.', 'airplane-mode' ),
+        ) );
     }
 
     /**

--- a/lib/js/airplane-mode.js
+++ b/lib/js/airplane-mode.js
@@ -1,0 +1,24 @@
+
+if ( window.jQuery ) {
+
+	jQuery.ajaxPrefilter( function( options, originalOptions, jqXHR ) {
+
+		if ( ! airmde.enabled ) {
+			return;
+		}
+
+		jqXHR.abort();
+
+		if ( originalOptions.fail && ( typeof originalOptions.fail === 'function' ) ) {
+			originalOptions.fail.call( jqXHR, jqXHR, 'abort' );
+		} else if ( originalOptions.error && ( typeof originalOptions.error === 'function' ) ) {
+			originalOptions.error.call( jqXHR, jqXHR, 'abort' );
+		}
+
+		if ( window.console ) {
+			console.warn( airmde.aborted.replace( '%1$s', options.url ) );
+		}
+
+	} );
+
+}


### PR DESCRIPTION
I thought you might like to know that I've been working on blocking AJAX requests when Airplane Mode is enabled.

This branch introduces some JavaScript which uses jQuery's `ajaxPrefilter` method to abort any jQuery AJAX request on the page. Currently it unconditionally aborts all AJAX requests which isn't very useful in the admin area; I'm finishing up a method for whitelisting domains complete with a filter.

One point of interest is that when calling the `abort()` method on the XHR before the request has begun means we have to manually call the `fail()` or `error()` callbacks because they don't get triggered. In case anyone wonders why we're manually calling those methods.

I'll update this PR as I work on this.
