### PR TITLE
Always disable Airplane Mode when using WP-CLI

### DIFF
--- a/airplane-mode.php
+++ b/airplane-mode.php
@@ -123,6 +123,9 @@ class Airplane_Mode_Core {
      * @return bool
      */
     public function enabled() {
+        if ( defined( 'WP_CLI' ) and WP_CLI ) {
+            return false;
+        }
         // pull our status from the options table
         return 'on' === get_option( 'airplane-mode' );
     }


### PR DESCRIPTION
Scenario: I'm on a slow connection so I have airplane mode enabled. I then decide to install a plugin via `wp plugin install foo-plugin`, but it fails due to airplane mode blocking the API request. I need to navigate to the site, disable airplane mode, re-run the command, then re-enable airplane mode.

I think it's fairly safe to just disable airplane mode whenever WP-CLI is being used. This patch does that.

Any objections?
