### PR TITLE
Prevent auto-updater from running when activated

### DIFF
--- a/airplane-mode.php
+++ b/airplane-mode.php
@@ -56,6 +56,7 @@ class Airplane_Mode_Core {
         add_action( 'wp_default_scripts', array( $this, 'block_script_load' ), 100   );
         add_filter( 'embed_oembed_html',  array( $this, 'block_oembed_html' ), 1,  4 );
         add_filter( 'get_avatar',         array( $this, 'replace_gravatar'  ), 1,  5 );
+        add_filter( 'map_meta_cap',       array( $this, 'prevent_auto_updates' ), 10, 2 );
 
         // kill all the http requests
         add_filter( 'pre_http_request', array( $this, 'disable_http_reqs' ), 10, 3 );
@@ -380,6 +381,20 @@ class Airplane_Mode_Core {
                 )
             )
         );
+    }
+
+    /**
+     * Filter a user's meta capabilities to prevent auto-updates from being attempted.
+     *
+     * @param array  $caps    Returns the user's actual capabilities.
+     * @param string $cap     Capability name.
+     * @return array
+     */
+    function prevent_auto_updates( $caps, $cap ) {
+        if ( in_array( $cap, array( 'update_plugins', 'update_themes', 'update_core' ) ) ) {
+            $caps[] = 'do_not_allow';
+        }
+        return $caps;
     }
 
 /// end class


### PR DESCRIPTION
On 4.1RC I'm getting errors triggered by a call in `wp-admin/menu.php` to `wp_get_update_data()` which then tries to call `wp_update_plugins()`, `wp_update_themes()`, and `get_core_updates()` if the user has these caps. The change in this PR removes the capabilities from the user so that these external calls are never made.
