### PR TITLE
Remove images from the default avatar list

### DIFF
--- a/airplane-mode.php
+++ b/airplane-mode.php
@@ -56,6 +56,7 @@ class Airplane_Mode_Core {
         add_filter( 'embed_oembed_html',  array( $this, 'block_oembed_html' ), 1,  4 );
         add_filter( 'get_avatar',         array( $this, 'replace_gravatar'  ), 1,  5 );
         add_filter( 'map_meta_cap',       array( $this, 'prevent_auto_updates' ), 10, 2 );
+		add_filter( 'default_avatar_select', array( $this, 'default_avatar' ) );
 
         // kill all the http requests
         add_filter( 'pre_http_request', array( $this, 'disable_http_reqs' ), 10, 3 );
@@ -248,6 +249,24 @@ class Airplane_Mode_Core {
         // return the item
         return $avatar;
     }
+
+	/**
+	 * Remove avatar images from the default avatar list
+	 *
+	 * @param  string $avatar_list List of default avatars
+	 * @return string              Updated list with images removed
+	 */
+	public function default_avatar( $avatar_list ) {
+		// bail if disabled
+		if ( ! $this->enabled() ) {
+		    return $avatar_list;
+		}
+
+		// remove images
+		$avatar_list = preg_replace('|<img([^>]+)> |i', '', $avatar_list);
+
+		return $avatar_list;
+	}
 
     /**
      * Disable all the HTTP requests being made with the action


### PR DESCRIPTION
The default avatar images on the Discussion Settings screen are broken because a query strings gets appended to the `data` URL.

This change simply removes the images from this section altogether.

![screen shot 2015-01-22 at 11 29 29](https://cloud.githubusercontent.com/assets/208434/5860927/9eb150ac-a22a-11e4-9c7f-ca079e2592be.png)