### PR TITLE
Don't wipe out the update array if Airplane Mode is disabled

### DIFF
--- a/airplane-mode.php
+++ b/airplane-mode.php
@@ -715,6 +715,11 @@ class Airplane_Mode_Core {
 	 * @return array           an empty array
 	 */
 	public function remove_update_array( $items ) {
+		// bail if disabled
+		if ( ! $this->enabled() ) {
+			return $items;
+		}
+
 		return array();
 	}
 


### PR DESCRIPTION
Looks like the merge in aa7ea19 went pretty wrong. `Airplane_Mode_Core::remove_update_array()` is wiping out the array of update data even when it's not enabled, which means every admin screen load triggers a WordPress.org API request.

This fixes that.