### PR TITLE
Don't break plugin tabs when Airplane Mode is disabled

### DIFF
--- a/airplane-mode.php
+++ b/airplane-mode.php
@@ -757,12 +757,12 @@ class Airplane_Mode_Core {
 
 		// bail if disabled
 		if ( ! $this->enabled() ) {
-			return $actions;
+			return $nonmenu_tabs;
 		}
 
 		// set an array of tabs to be removed with optional filter
 		if ( false === $remove = apply_filters( 'airplane_mode_bulk_items', array( 'featured', 'popular', 'recommended', 'favorites' ) ) ) {
-			return $actions;
+			return $nonmenu_tabs;
 		}
 
 		// loop the item array and unset each


### PR DESCRIPTION
`Airplane_Mode_Core::plugin_add_tabs()` breaks the Add Plugin screen tabs when Airplane Mode is disabled.