### PR TITLE
Don't try to re-define constants if they're already defined

### DIFF
--- a/airplane-mode.php
+++ b/airplane-mode.php
@@ -168,8 +168,12 @@ class Airplane_Mode_Core {
 			add_action( 'install_themes_upload',    'install_themes_upload', 10, 0 );
 
 			// Define core contants for more protection
-			define( 'AUTOMATIC_UPDATER_DISABLED', true );
-			define( 'WP_AUTO_UPDATE_CORE', false );
+			if ( ! defined( 'AUTOMATIC_UPDATER_DISABLED' ) ) {
+				define( 'AUTOMATIC_UPDATER_DISABLED', true );
+			}
+			if ( ! defined( 'WP_AUTO_UPDATE_CORE' ) ) {
+				define( 'WP_AUTO_UPDATE_CORE', false );
+			}
 		}
 	}
 


### PR DESCRIPTION
If either of the `WP_AUTO_UPDATE_CORE` or `AUTOMATIC_UPDATER_DISABLED` constants are already defined, Airplane Mode triggers an `already defined` PHP notice.