### PR TITLE
Move the HTTP counter into the Airplane Mode status indicator

### DIFF
--- a/airplane-mode.php
+++ b/airplane-mode.php
@@ -494,11 +494,15 @@ class Airplane_Mode_Core {
 		// get my text
 		$text   = __( 'Airplane Mode', 'airplane-mode' );
 
-		// get my icon
-		$icon   = '<span class="airplane-toggle-icon ' . sanitize_html_class( $class ) . '"></span>';
-
 		// get the HTTP count
-		$count  = '<span class="airplane-http-count">' . absint( $this->http_count ) . '</span>';
+		if ( ! empty( $this->http_count ) ) {
+			$count = number_format_i18n( $this->http_count );
+		} else {
+			$count = '';
+		}
+
+		// get my icon
+		$icon   = '<span class="airplane-toggle-icon ' . sanitize_html_class( $class ) . '">' . $count . '</span>';
 
 		// get our link with the status parameter
 		$link   = wp_nonce_url( add_query_arg( 'airplane-mode', $toggle ), 'airmde_nonce', 'airmde_nonce' );
@@ -507,7 +511,7 @@ class Airplane_Mode_Core {
 		$wp_admin_bar->add_menu(
 			array(
 				'id'        => 'airplane-mode-toggle',
-				'title'     => $count . $icon . $text,
+				'title'     => $icon . $text,
 				'href'      => esc_url( $link ),
 				'position'  => 0,
 				'meta'      => array(

--- a/lib/css/airplane-mode.css
+++ b/lib/css/airplane-mode.css
@@ -1,6 +1,6 @@
 #wp-admin-bar-airplane-mode-toggle span.airplane-toggle-icon {
-	height: 14px;
-	width: 14px;
+	height: 18px;
+	width: 18px;
 	border-radius: 50%;
 	background: #ccc;
 	display: inline-block;
@@ -8,6 +8,10 @@
 	margin-right: 7px;
 	position: relative;
 	bottom: 2px;
+	color: #eee;
+	text-align: center;
+	vertical-align: middle;
+	line-height: 19px;
 }
 
 #wp-admin-bar-airplane-mode-toggle span.airplane-toggle-icon-on {
@@ -16,20 +20,6 @@
 
 #wp-admin-bar-airplane-mode-toggle span.airplane-toggle-icon-off {
 	background: red;
-}
-
-#wp-admin-bar-airplane-mode-toggle span.airplane-http-count {
-	position: relative;
-	display: inline-block;
-	width: 21px;
-	height: 21px;
-	line-height: 21px;
-	margin-right: 7px;
-	border-radius: 50%;
-	background-color: #d3d3d3;
-	color: #000;
-	text-align: center;
-	font-weight: bold;
 }
 
 .plugin-install-php a.upload.add-new-h2,


### PR DESCRIPTION
The HTTP counter looks pretty terrible next to the status indicator, what with it being a different size.

This change moves the HTTP request counter into the status indicator, tidies it up a bit, and removes the counter text when it's at zero.