### PR TITLE
change Plugin URI to GitHub

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+#### Version 0.0.7 - 2015/04/21
+* fixed some CSS from hiding plugins page bar
+* moved changelog to it's own file
+* added `composer.json`
+
 #### Version 0.0.6 - 2015/04/02
 * version bump for GitHub updater
 

--- a/airplane-mode.php
+++ b/airplane-mode.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Plugin Name: Airplane Mode
-Plugin URI: http://reaktivstudios.com/
+Plugin URI: https://github.com/norcross/airplane-mode
 Description: Control loading of external files when developing locally
 Author: Andrew Norcross
 Version: 0.0.6

--- a/airplane-mode.php
+++ b/airplane-mode.php
@@ -4,7 +4,7 @@ Plugin Name: Airplane Mode
 Plugin URI: https://github.com/norcross/airplane-mode
 Description: Control loading of external files when developing locally
 Author: Andrew Norcross
-Version: 0.0.6
+Version: 0.0.7
 Requires WP: 3.7
 Author URI: http://reaktivstudios.com/
 GitHub Plugin URI: https://github.com/norcross/airplane-mode
@@ -34,7 +34,7 @@ if ( ! defined( 'AIRMDE_DIR' ) ) {
 }
 
 if ( ! defined( 'AIRMDE_VER' ) ) {
-	define( 'AIRMDE_VER', '0.0.6' );
+	define( 'AIRMDE_VER', '0.0.7' );
 }
 
 /**

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Donate link: https://andrewnorcross.com/donate
 Tags: external calls, HTTP
 Requires at least: 3.7
 Tested up to: 4.1
-Stable tag: 0.0.6
+Stable tag: 0.0.7
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -41,6 +41,11 @@ Because you are a jet set developer who needs to work without internet.
 
 
 == Changelog ==
+
+= 0.0.7 - 2015/04/21 =
+  * fixed some CSS from hiding plugins page bar
+  * moved changelog to it's own file
+  * added `composer.json`
 
 = 0.0.6 - 2015/04/02 =
 * version bump for GitHub updater

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: norcross
 Donate link: https://andrewnorcross.com/donate
 Tags: external calls, HTTP
 Requires at least: 3.7
-Tested up to: 4.1
+Tested up to: 4.2
 Stable tag: 0.0.7
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
added benefit of expanded 'View details' link on plugins.php

In latest develop branch of GitHub Updater a readme.txt file is parsed and used in the 'View details' screen. In order for it to work the `Plugin URI === GitHub Plugin URI`

![screenshot_01](https://cloud.githubusercontent.com/assets/1296790/7267722/26071f48-e874-11e4-8540-3b6cf5a6df26.png)
