### PR TITLE
Better blocked assets

### DIFF
--- a/airplane-mode.php
+++ b/airplane-mode.php
@@ -284,7 +284,12 @@ if ( ! class_exists( 'Airplane_Mode_Core' ) ) {
 			}
 
 			// If we don't share the same URL as the site itself, return null. Otherwise return the URL.
-			return isset( $parsed ) && false === strpos( home_url(), $parsed ) ? null : $source;
+			return isset( $parsed ) && false === strpos( home_url(), $parsed )
+				? new Airplane_Mode_WP_Error( 'airplane_mode_enabled', __( 'Airplane Mode blocked style', 'airplane-mode' ), array(
+					'return' => '',
+					'src'    => $source,
+				) )
+				: $source;
 		}
 
 		/**
@@ -310,7 +315,12 @@ if ( ! class_exists( 'Airplane_Mode_Core' ) ) {
 			}
 
 			// If we don't share the same URL as the site itself, return null. Otherwise return the URL.
-			return isset( $parsed ) && false === strpos( home_url(), $parsed ) ? null : $source;
+			return isset( $parsed ) && false === strpos( home_url(), $parsed )
+				? new Airplane_Mode_WP_Error( 'airplane_mode_enabled', __( 'Airplane Mode blocked script', 'airplane-mode' ), array(
+					'return' => '',
+					'src'    => $source,
+				) )
+				: $source;
 		}
 
 		/**

--- a/airplane-mode.php
+++ b/airplane-mode.php
@@ -888,6 +888,18 @@ if ( ! class_exists( 'Airplane_Mode_Core' ) ) {
 
 } //end class_exists
 
+if ( ! class_exists( 'Airplane_Mode_WP_Error' ) ) {
+
+	class Airplane_Mode_WP_Error extends WP_Error {
+
+		public function __tostring() {
+			$data = $this->get_error_data();
+			return $data['return'];
+		}
+
+	}
+
+}
 
 // Instantiate our class.
 $Airplane_Mode_Core = Airplane_Mode_Core::getInstance();


### PR DESCRIPTION
So here's an idea that I had.

When Airplane Mode blocks remote scripts and styles from loading, it uses the `script_loader_src` filter rather than altering the `src` property of the `_WP_Dependency` object directly. This means, for example, that Query Monitor still reports the remote asset and its source URL as if nothing is wrong:

<img width="789" alt="" src="https://cloud.githubusercontent.com/assets/208434/13265634/e533d304-da6b-11e5-9d81-ebbe7099b41a.png">

I altered Query Monitor so it applies the `script_loader_src` filter to the source before outputting it, but that change results in an empty URL:

<img width="789" alt="" src="https://cloud.githubusercontent.com/assets/208434/13265664/0c20992a-da6c-11e5-9426-fb8c8c6e7e11.png">

With the change in this PR, Airplane Mode instead returns an extended `WP_Error` object that contains a `__tostring()` method which is automatically called by anything which treats the source as a string( eg. the `WP_Dependencies` class when it nullifies the asset's source URL). I can then modify Query Monitor to explicitly check for a `WP_Error` and display a more informative message when necessary:

<img width="789" alt="screen shot 2016-02-23 at 20 12 46" src="https://cloud.githubusercontent.com/assets/208434/13265723/677ca764-da6c-11e5-8851-77134c540b5d.png">

Whaddayathink?