### PR TITLE
Don't attempt to remove the `index.php` submenu page

### DIFF
--- a/airplane-mode.php
+++ b/airplane-mode.php
@@ -397,7 +397,6 @@ if ( ! class_exists( 'Airplane_Mode_Core' ) ) {
 
 			// Remove our items.
 			remove_submenu_page( 'index.php', 'update-core.php' );
-			remove_submenu_page( 'index.php', 'index.php' );
 		}
 
 		/**


### PR DESCRIPTION
If you install a plugin which adds a submenu to the `Dashboard` admin menu, such as [Simple History](https://wordpress.org/plugins/simple-history/), then Airplane Mode causes the top level `Dashboard` menu item to link to the submenu instead of `index.php`.

This change fixes that.

cc @chriscct7 - was there a reason for this line of code?