### PR TITLE
Allow locally defined constant to override filter.

### DIFF
--- a/airplane-mode.php
+++ b/airplane-mode.php
@@ -139,8 +139,11 @@ if ( ! class_exists( 'Airplane_Mode_Core' ) ) {
 			// All our various filter checks.
 			if ( $this->enabled() ) {
 
-				// Keep jetpack from attempting external requests.
-				add_filter( 'jetpack_development_mode',             '__return_true', 9999 );
+				// Allows locally defined JETPACK_DEV_DEBUG constant to override filter.
+				if ( ! defined( 'JETPACK_DEV_DEBUG' ) ) {
+					// Keep jetpack from attempting external requests.
+					add_filter( 'jetpack_development_mode',         '__return_true', 9999 );
+				}
 
 				// Disable automatic updater updates.
 				add_filter( 'automatic_updater_disabled',           '__return_true' );


### PR DESCRIPTION
While working locally, I ran into a (rare) situation which I needed to set `JETPACK_DEV_DEBUG` to `false` momentarily. However, because of the filter set in Airplane Mode, I also had to set it to Inactive (which is not really an issue).

That being said, it seems the locally defined constant _should_ override the filter in this case and this commit addresses that issue.