### PR TITLE
Only load styles if the admin bar is visible

### DIFF
--- a/airplane-mode.php
+++ b/airplane-mode.php
@@ -104,7 +104,6 @@ if ( ! class_exists( 'Airplane_Mode_Core' ) ) {
 			add_action( 'admin_bar_menu',                       array( $this, 'admin_bar_toggle'        ),  9999    );
 			add_action( 'wp_enqueue_scripts',                   array( $this, 'toggle_css'              ),  9999    );
 			add_action( 'admin_enqueue_scripts',                array( $this, 'toggle_css'              ),  9999    );
-			add_action( 'login_enqueue_scripts',                array( $this, 'toggle_css'              ),  9999    );
 
 			// Body class on each location for the display.
 			add_filter( 'body_class',                           array( $this, 'body_class'              )           );

--- a/airplane-mode.php
+++ b/airplane-mode.php
@@ -515,6 +515,10 @@ if ( ! class_exists( 'Airplane_Mode_Core' ) ) {
 		 */
 		public function toggle_css() {
 
+			if ( ! is_admin_bar_showing() ) {
+				return;
+			}
+
 			// Set a suffix for loading the minified or normal.
 			$suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '.css' : '.min.css';
 


### PR DESCRIPTION
Currently styles are loaded when the user is not logged in. The plugin css styles however only apply to the admin bar and to some areas of the admin. Also, there is no need to enqueue the styles on the login page.