### PR TITLE
Handle locally installed languages which aren't in Airplane Mode's offline list.

### DIFF
--- a/airplane-mode.php
+++ b/airplane-mode.php
@@ -1014,7 +1014,9 @@ if ( ! class_exists( 'Airplane_Mode_Core' ) ) {
 				);
 
 				// Combine the mimicked data with data we have stored in $offline_languages to give realistic output.
-				$available_languages[ $lang ] = array_merge( $settings, $offline_languages[ $lang ] );
+				if ( isset( $offline_languages[ $lang ] ) ) {
+					$available_languages[ $lang ] = array_merge( $settings, $offline_languages[ $lang ] );
+				}
 			}
 
 			// And return our language sets.


### PR DESCRIPTION
If you install a language that's not in Airplane Mode's offline list of languages (in `Airplane_Mode_Core::get_offline_translation_information()`) then you'll get the following PHP warning on the General Settings screen:

```
Warning: array_merge(): Argument #2 is not an array
wp-content/plugins/airplane-mode/airplane-mode.php:1013
```

You can see this by installing the Afrikaans (`af`) language while online, then going offline with Airplane Mode.

This fix removes the PHP warning and results in just the language code being displayed in the language dropdown.

<img width="413" alt="screen shot 2017-03-21 at 13 23 26" src="https://cloud.githubusercontent.com/assets/208434/24149219/a1f2b3fa-0e39-11e7-9886-7cb2bb176df6.png">

A separate issue is that Airplane Mode's offline list of languages is incomplete. I'll address this in a separate PR.