### PR TITLE
Implement a filter which allows an HTTP API request to pass through

### DIFF
--- a/airplane-mode.php
+++ b/airplane-mode.php
@@ -510,6 +510,11 @@ if ( ! class_exists( 'Airplane_Mode_Core' ) ) {
 				}
 			}
 
+			// Allow certain HTTP API requests to pass through via a filter.
+			if ( apply_filters( 'airplane_mode_allow_http_api_request', false, $url, $args, $url_host ) ) {
+				return $status;
+			}
+
 			// Disable the http requests if enabled.
 			return new WP_Error( 'airplane_mode_enabled', __( 'Airplane Mode is enabled', 'airplane-mode' ) );
 		}


### PR DESCRIPTION
When Airplane Mode is enabled, all requests that go through the WordPress HTTP API get blocked. Sometimes I want to allow certain HTTP API requests through, for example ones which are actually locally accessible.

This filter allows a request to pass through by returning a boolean `true` value. Example:

```php
add_filter( 'airplane_mode_allow_http_api_request', function( $status, $url, $args, $url_host ) {
	if ( 'example.com' === $url_host ) {
		// Allow requests to example.com to pass through and not be blocked:
		return true;
	}
	return $status;
}, 10, 4 );
```