### PR TITLE
Remove usage of method that's deprecated in WordPress trunk

### DIFF
--- a/airplane-mode.php
+++ b/airplane-mode.php
@@ -725,7 +725,7 @@ if ( ! class_exists( 'Airplane_Mode_Core' ) ) {
 			$link = wp_nonce_url( add_query_arg( 'airplane-mode', $toggle ), 'airmde_nonce', 'airmde_nonce' );
 
 			// Now add the admin bar link.
-			$wp_admin_bar->add_menu(
+			$wp_admin_bar->add_node(
 				array(
 					'id'        => 'airplane-mode-toggle',
 					'title'     => '<span class="ab-icon"></span>' . $label,


### PR DESCRIPTION
Bit of an annoying deprecation in core trunk. `add_node()` now needs to be used instead of `add_menu()`.

Ref: https://core.trac.wordpress.org/ticket/19647