### PR TITLE
I noticed that when $source refers to a relative URL, the value retur…

### DIFF
--- a/airplane-mode.php
+++ b/airplane-mode.php
@@ -334,7 +334,7 @@ if ( ! class_exists( 'Airplane_Mode_Core' ) ) {
 			$parsed = parse_url( $source, PHP_URL_HOST );
 
 			// First run the filter to allow a source host to get through.
-			if ( false === apply_filters( 'airplane_mode_parse_script', true, $parsed ) ) {
+			if ( false === apply_filters( 'airplane_mode_parse_script', true, $parsed ) || false === $parsed ) {
 				return $source;
 			}
 


### PR DESCRIPTION
…ned from parse_url() is false. This causes a Deprecated warning message to be displayed when strpos() is called a few lines later. This change avoids that issue and reduces non-fatal messages from being displayed.