### PR TITLE
Replace Avatars with Colored Images

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+#### Version 0.2.7 - 2024/11/12
+* Replacing dull monotone avatars with color ones. props @akirk
+
 #### Version 0.2.6 - 2022/10/13
 * Remove usage of 'jetpack_development_mode' that's been deprecated. props @crstauf
 * Gracefully handle empty values for script and stylesheet URLs. props @johnbillion

--- a/airplane-mode.php
+++ b/airplane-mode.php
@@ -495,7 +495,7 @@ if ( ! class_exists( 'Airplane_Mode_Core' ) ) {
 		public function replace_gravatar( $avatar, $id_or_email, $size, $default, $alt ) {
 
 			// Bail if disabled.
-			if ( ! $this->enabled() ) {
+			if ( ! $this->enabled() || false === strpos( $avatar, 'gravatar.com' ) ) {
 				return $avatar;
 			}
 

--- a/airplane-mode.php
+++ b/airplane-mode.php
@@ -508,7 +508,6 @@ if ( ! class_exists( 'Airplane_Mode_Core' ) ) {
 			$mem = fopen( 'php://memory', 'rb+' );
 			imagepng( $im, $mem );
 			rewind( $mem );
-			$image_data = ;
 			imagedestroy( $im );
 			$image = 'data:image/png;base64,' . base64_encode( stream_get_contents( $mem ) );
 			fclose( $mem );

--- a/airplane-mode.php
+++ b/airplane-mode.php
@@ -5,7 +5,7 @@
  * Description: Control loading of external files when developing locally.
  * Author: Andrew Norcross
  * Author URI: http://andrewnorcross.com/
- * Version: 0.2.6
+ * Version: 0.2.7
  * Text Domain: airplane-mode
  * Requires WP: 4.4
  * Domain Path: languages
@@ -49,7 +49,7 @@ if ( ! defined( 'AIRMDE_DIR' ) ) {
 
 // Set our version if not already defined.
 if ( ! defined( 'AIRMDE_VER' ) ) {
-	define( 'AIRMDE_VER', '0.2.6' );
+	define( 'AIRMDE_VER', '0.2.7' );
 }
 
 // Load our WP-CLI helper if that is defined and available.

--- a/airplane-mode.php
+++ b/airplane-mode.php
@@ -499,8 +499,20 @@ if ( ! class_exists( 'Airplane_Mode_Core' ) ) {
 				return $avatar;
 			}
 
-			// Swap out the file for a base64 encoded image.
-			$image  = 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==';
+			// Swap out the file for a base64 encoded image generated based on the $id_or_email.
+			$hash = md5( strtolower( trim( $id_or_email ) ) );
+			$im = imagecreatetruecolor( 1, 1 );
+			$rgb = sscanf( $hash, '%2x%2x%2x' );
+			$color = imagecolorallocate( $im, $rgb[0], $rgb[1], $rgb[2] );
+			imagesetpixel( $im, 0, 0, $color );
+			$mem = fopen( 'php://memory', 'rb+' );
+			imagepng( $im, $mem );
+			rewind( $mem );
+			$image_data = ;
+			imagedestroy( $im );
+			$image = 'data:image/png;base64,' . base64_encode( stream_get_contents( $mem ) );
+			fclose( $mem );
+			
 			$avatar = "<img alt='{$alt}' src='{$image}' class='avatar avatar-{$size} photo' height='{$size}' width='{$size}' style='background:#eee;' />";
 
 			// Return the avatar.

--- a/airplane-mode.php
+++ b/airplane-mode.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://github.com/norcross/airplane-mode
  * Description: Control loading of external files when developing locally.
  * Author: Andrew Norcross
- * Author URI: http://andrewnorcross.com/
+ * Author URI: https://andrewnorcross.com/
  * Version: 0.2.7
  * Text Domain: airplane-mode
  * Requires WP: 4.4

--- a/airplane-mode.php
+++ b/airplane-mode.php
@@ -500,6 +500,9 @@ if ( ! class_exists( 'Airplane_Mode_Core' ) ) {
 			}
 
 			// Swap out the file for a base64 encoded image generated based on the $id_or_email.
+			$image = $this->generate_color_avatar( $id_or_email );
+
+			/*
 			$hash = md5( strtolower( trim( $id_or_email ) ) );
 			$im = imagecreatetruecolor( 1, 1 );
 			$rgb = sscanf( $hash, '%2x%2x%2x' );
@@ -511,6 +514,7 @@ if ( ! class_exists( 'Airplane_Mode_Core' ) ) {
 			imagedestroy( $im );
 			$image = 'data:image/png;base64,' . base64_encode( stream_get_contents( $mem ) );
 			fclose( $mem );
+			*/
 			
 			$avatar = "<img alt='{$alt}' src='{$image}' class='avatar avatar-{$size} photo' height='{$size}' width='{$size}' style='background:#eee;' />";
 
@@ -1294,6 +1298,56 @@ if ( ! class_exists( 'Airplane_Mode_Core' ) ) {
 		 */
 		public function count_http_requests() {
 			$this->http_count++;
+		}
+
+		/**
+		 * Generate a color avatar because it looks nice.
+		 *
+		 * @param  int|object|string $id_or_email  A user ID, email address, or comment object.
+		 *
+		 * @return string
+		 */
+		public function generate_color_avatar( $id_or_email ) {
+
+			// Set the user string we are gonna use for the hash.
+			// If it's an object, then it's from comments, so parse it out.
+			$define_user_sr = is_object( $id_or_email ) ? $id_or_email->comment_author_email : $id_or_email;
+
+			// Swap out the file for a base64 encoded image generated based on the $id_or_email.
+			$generate_hash  = md5( strtolower( trim( $id_or_email ) ) );
+
+			// Set a color image.
+			$color_image    = imagecreatetruecolor( 1, 1 );
+
+			// Set up the RGB base.
+			$base_rgb_array = sscanf( $generate_hash, '%2x%2x%2x' );
+
+			// Now generate the color itself.
+			$generate_color = imagecolorallocate( $color_image, $base_rgb_array[0], $base_rgb_array[1], $base_rgb_array[2] );
+
+			// Set pixels for the image.
+			imagesetpixel( $color_image, 0, 0, $generate_color );
+
+			// Begin generating the image.
+			$generate_image = fopen( 'php://memory', 'rb+' );
+
+			// Create the PNG.
+			imagepng( $color_image, $generate_image );
+
+			// Be Kind.
+			rewind( $generate_image );
+
+			// Finish up.
+			imagedestroy( $color_image );
+
+			// Set the data up.
+			$set_image_data = 'data:image/png;base64,' . base64_encode( stream_get_contents( $generate_image ) );
+
+			// Close the access.
+			fclose( $generate_image );
+
+			// And return the resulting image.
+			return $set_image_data;
 		}
 
 		// End class.

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Donate link: https://andrewnorcross.com/donate
 Tags: external calls, HTTP
 Requires at least: 4.4
 Tested up to: 6.0
-Stable tag: 0.2.6
+Stable tag: 0.2.7
 License: MIT
 License URI: http://norcross.mit-license.org/
 
@@ -44,6 +44,9 @@ Because you are a jet set developer who needs to work without internet.
 
 
 == Changelog ==
+
+= 0.2.7 - 2024/11/12
+* Replacing dull monotone avatars with color ones. props @akirk
 
 = 0.2.6 - 2022/10/13
 * Remove usage of 'jetpack_development_mode' that's been deprecated. props @crstauf

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Website Link: https://github.com/norcross/airplane-mode
 Donate link: https://andrewnorcross.com/donate
 Tags: external calls, HTTP
 Requires at least: 4.4
-Tested up to: 6.0
+Tested up to: 6.7
 Stable tag: 0.2.7
 License: MIT
 License URI: http://norcross.mit-license.org/


### PR DESCRIPTION
This allows to distinguish local users via avatars based on the image color. It also doesn't override a locally provided image for example via https://github.com/10up/simple-local-avatars.

![Screenshot 2024-05-10 at 09 47 26](https://github.com/norcross/airplane-mode/assets/203408/0ae35b97-bc95-4b97-aba4-9f62163b13a3)
