### PR TITLE
Check if `is_plugin_active` exists

### DIFF
--- a/airplane-mode.php
+++ b/airplane-mode.php
@@ -155,7 +155,7 @@ if ( ! class_exists( 'Airplane_Mode_Core' ) ) {
 				// Allows locally defined JETPACK_DEV_DEBUG constant to override filter.
 				if ( ! defined( 'JETPACK_DEV_DEBUG' ) ) {
 					
-					if ( ! function_exists( 'get_plugin_data' ) ) {
+					if ( ! function_exists( 'get_plugin_data' ) || ! function_exists( 'is_plugin_active' ) ) {
 						require_once ABSPATH . 'wp-admin/includes/plugin.php';
 					}
 					


### PR DESCRIPTION
With https://core.trac.wordpress.org/changeset/59461, `get_plugin_data` is now available earlier, but `is_plugin_active` isn't.

cc @johnbillion 